### PR TITLE
Fix/hidden validation bug

### DIFF
--- a/tom_swift/templates/tom_swift/observation_form.html
+++ b/tom_swift/templates/tom_swift/observation_form.html
@@ -128,6 +128,10 @@ function showHideSwiftGIProposalFields() {
     }
 };
 
+function showExposureAccordianOnError() {
+    const exposureAccordion = document.getElementById('exposure-visit-information');
+    exposureAccordion.classList.add('show');
+}
 </script>
 
 <script type="text/javascript">
@@ -220,6 +224,12 @@ function showHideSwiftGIProposalFields() {
     var el6 = document.getElementById("div_id_grb_detector_choices");
     //el6.addEventListener("click", showHideGRBDetectionFields);
     el6.addEventListener("change", showHideTargetClassificationFields);
+
+    var el7 = document.getElementById("id_exposure");
+    el7.addEventListener("invalid", showExposureAccordianOnError);
+
+    var el8 = document.getElementById("id_exp_time_just");
+    el8.addEventListener("invalid", showExposureAccordianOnError);
 </script>
 
 {% endblock %}


### PR DESCRIPTION
This is a highly specific change to fix a very specific problem. 
This code will prevent silent failures when the exposure time and the exposure time justification fields are invalid while the outside accordion is closed. This will open the accordion and display that the invalid field needs to be handled.

With a bit more effort, I believe something similar could be implemented that does this more generally.