### PR TITLE
add Urgency 0

### DIFF
--- a/tom_swift/swift_api.py
+++ b/tom_swift/swift_api.py
@@ -79,6 +79,7 @@ SWIFT_OTHER_CHOICE = 'Other (please specify)'
 # Urgency
 #
 SWIFT_URGENCY_CHOICES = [
+    (0, 'Immediately (Urgency 0)')
     (1, 'Within 4 hours (Wakes up the Swift Observatory Duty Scientist).'),
     (2, 'Within 24 hours'),
     (3, 'Days to a week'),  # default

--- a/tom_swift/swift_api.py
+++ b/tom_swift/swift_api.py
@@ -79,7 +79,7 @@ SWIFT_OTHER_CHOICE = 'Other (please specify)'
 # Urgency
 #
 SWIFT_URGENCY_CHOICES = [
-    (0, 'Immediately (Urgency 0)')
+    (0, 'Immediately (Urgency 0)'),
     (1, 'Within 4 hours (Wakes up the Swift Observatory Duty Scientist).'),
     (2, 'Within 24 hours'),
     (3, 'Days to a week'),  # default


### PR DESCRIPTION
As of Cycle 21, Swift offers ToOs with Urgency 0 for some approved GI programs (see the [call for proposals](https://swift.gsfc.nasa.gov/proposals/swiftgi.html)). This PR adds that as an option to the urgency dropdown menu.